### PR TITLE
テナント一覧の利便性向上とフォーム送信処理の修正

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -1,9 +1,11 @@
 import axios from "axios";
 import { useEffect } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
 
 const Auth = () => {
+  const location = useLocation();
+
   // ログインユーザの情報を取得
   const getUserInfo = async () => {
     try {
@@ -12,7 +14,7 @@ const Auth = () => {
         headers: {
           "X-Requested-With": "XMLHttpRequest",
           Authorization: `Bearer ${jwtToken}`,
-          "X-SaaSus-Referer": "GetUserInfo",
+          "X-SaaSus-Referer": location.pathname,
         },
         withCredentials: true,
       });

--- a/src/pages/SelfSignUp.tsx
+++ b/src/pages/SelfSignUp.tsx
@@ -159,14 +159,34 @@ const SelfSignup = () => {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
+    // 空の値を除外したユーザー属性値を作成
+    const filteredUserAttributeValues = Object.fromEntries(
+      Object.entries(userAttributeValues).filter(([_, value]) => {
+        if (value === null || value === undefined) return false;
+        if (typeof value === "string" && value.trim() === "") return false;
+        if (typeof value === "number" && isNaN(value)) return false;
+        return true;
+      })
+    );
+
+    // 空の値を除外したテナント属性値を作成
+    const filteredTenantAttributeValues = Object.fromEntries(
+      Object.entries(tenantAttributeValues).filter(([_, value]) => {
+        if (value === null || value === undefined) return false;
+        if (typeof value === "string" && value.trim() === "") return false;
+        if (typeof value === "number" && isNaN(value)) return false;
+        return true;
+      })
+    );
+
     try {
       // セルフサインアップ処理
       await axios.post(
         `${API_ENDPOINT}/self_sign_up`,
         {
           tenantName,
-          userAttributeValues,
-          tenantAttributeValues,
+          userAttributeValues: filteredUserAttributeValues,
+          tenantAttributeValues: filteredTenantAttributeValues,
         },
         {
           headers: {

--- a/src/pages/TenantList.tsx
+++ b/src/pages/TenantList.tsx
@@ -123,6 +123,9 @@ const TenantList = () => {
             <thead className="bg-gray-100">
               <tr>
                 <th className="py-3 px-4 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
+                  アクション
+                </th>
+                <th className="py-3 px-4 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
                   テナントID
                 </th>
                 <th className="py-3 px-4 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
@@ -137,14 +140,19 @@ const TenantList = () => {
                       {tenantInfo[0][key].display_name}
                     </th>
                   ))}
-                <th className="py-3 px-4 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
-                  アクション
-                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
               {tenants?.map((tenant: Tenant, tenantIndex: number) => (
                 <tr key={tenant.id} className="hover:bg-gray-50">
+                  <td className="py-3 px-4 whitespace-nowrap">
+                    <button
+                      onClick={() => handleUserListClick(tenant.id)}
+                      className="py-1 px-3 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"
+                    >
+                      ユーザー一覧に移動
+                    </button>
+                  </td>
                   <td className="py-3 px-4 whitespace-nowrap">{tenant.id}</td>
                   <td className="py-3 px-4 whitespace-nowrap">{tenant.name}</td>
                   {tenantInfo[tenantIndex] &&
@@ -159,14 +167,6 @@ const TenantList = () => {
                         </td>
                       );
                     })}
-                  <td className="py-3 px-4 whitespace-nowrap">
-                    <button
-                      onClick={() => handleUserListClick(tenant.id)}
-                      className="py-1 px-3 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"
-                    >
-                      ユーザー一覧に移動
-                    </button>
-                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -334,14 +334,29 @@ const UserPage = () => {
         </div>
       )}
 
-      {/* ログアウトボタン */}
-      <div className="mt-6 flex justify-end">
-        <button
-          onClick={handleLogout}
-          className="py-2 px-4 bg-gray-600 text-white rounded hover:bg-gray-700"
-        >
-          ログアウト
-        </button>
+      {/* ナビゲーションリンク */}
+      <div className="mt-6 flex justify-between items-center">
+        {/* テナント一覧に戻るリンク（複数テナントに所属している場合のみ表示） */}
+        {userinfo && userinfo.tenants && userinfo.tenants.length > 1 && (
+          <div>
+            <a
+              href="/tenants"
+              className="text-blue-600 hover:text-blue-800 hover:underline"
+            >
+              テナント一覧に戻る
+            </a>
+          </div>
+        )}
+        
+        {/* ログアウトボタン */}
+        <div>
+          <button
+            onClick={handleLogout}
+            className="py-2 px-4 bg-gray-600 text-white rounded hover:bg-gray-700"
+          >
+            ログアウト
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/UserRegister.tsx
+++ b/src/pages/UserRegister.tsx
@@ -111,6 +111,16 @@ const UserRegister = () => {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
+    // 空の値を除外したユーザー属性値を作成
+    const filteredUserAttributeValues = Object.fromEntries(
+      Object.entries(userAttributeValues).filter(([_, value]) => {
+        if (value === null || value === undefined) return false;
+        if (typeof value === "string" && value.trim() === "") return false;
+        if (typeof value === "number" && isNaN(value)) return false;
+        return true;
+      })
+    );
+
     try {
       await axios.post(
         `${API_ENDPOINT}/user_register`,
@@ -118,7 +128,7 @@ const UserRegister = () => {
           email,
           password,
           tenantId,
-          userAttributeValues,
+          userAttributeValues: filteredUserAttributeValues,
         },
         {
           headers: {


### PR DESCRIPTION
・src/components/Auth.tsxのgetUserInfoでX-SaaSus-Referer ヘッダーに、画面の現在パスを設定する。
・テナント一覧テーブルの操作列（Action Column）を先頭の位置に移動。
・複数テナントに属するユーザー向けに、ユーザー一覧からテナント一覧画面へ遷移するためのリンクを追加。
・ユーザー新規登録、セルフサインアップのフォームサブミット時に値が入力されていない属性のキーは送信しない。