### PR TITLE
Auth取得のuserinfoをContextで共有し、ヘッダーおよびユーザー一覧の表示をemail/sign_in_id対応に統一

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import BillingDashboard from "./pages/BillingDashboard";
 import PlanSettings from "./pages/PlanSettings";
 import HeaderUserbox from "./components/header/HeaderUserbox";
 import UserInvitation from "./pages/UserInvitation";
+import { UserProvider } from "./contexts/UserContext";
 
 const AppContent = () => {
   const location = useLocation();
@@ -52,7 +53,9 @@ const AppContent = () => {
 function App() {
   return (
     <BrowserRouter>
-      <AppContent />
+      <UserProvider>
+        <AppContent />
+      </UserProvider>
     </BrowserRouter>
   );
 }

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -2,15 +2,18 @@ import axios from "axios";
 import { useEffect } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
+import { useUser } from "../contexts/UserContext";
+import { UserInfo } from "../types";
 
 const Auth = () => {
   const location = useLocation();
+  const { setUserInfo } = useUser();
 
   // ログインユーザの情報を取得
   const getUserInfo = async () => {
     try {
       const jwtToken = window.localStorage.getItem("SaaSusIdToken");
-      const res = await axios.get(`${API_ENDPOINT}/userinfo`, {
+      const res = await axios.get<UserInfo>(`${API_ENDPOINT}/userinfo`, {
         headers: {
           "X-Requested-With": "XMLHttpRequest",
           Authorization: `Bearer ${jwtToken}`,
@@ -28,8 +31,12 @@ const Auth = () => {
     getUserInfo().then((res) => {
       // ログインユーザの情報が取得できない（ログインが確認できない）場合、ログイン画面に遷移
       if (!res) {
+        setUserInfo(null);
         window.location.href = LOGIN_URL;
+        return;
       }
+
+      setUserInfo(res.data);
     });
   }, []);
 

--- a/src/components/header/HeaderUserbox.tsx
+++ b/src/components/header/HeaderUserbox.tsx
@@ -1,26 +1,15 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import UserMfaSettingDialog from "../dialogs/UserMfaSettingDialog";
 import { idTokenCheck } from "../../utils";
+import { useUser } from "../../contexts/UserContext";
 
 const HeaderUserbox = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [mfaDialogOpen, setMfaDialogOpen] = useState(false);
-  const [email, setEmail] = useState<string | null>(null); // メールアドレス用の状態
+  const { userInfo } = useUser();
 
-  useEffect(() => {
-    const idToken = localStorage.getItem("SaaSusIdToken");
-    if (idToken) {
-      try {
-        const decodedToken = decodeJwtPayload(idToken);
-        setEmail(decodedToken?.email || "未設定");
-      } catch (error) {
-        console.error("IDトークンのデコードに失敗しました", error);
-        setEmail("取得失敗");
-      }
-    } else {
-      setEmail("未ログイン");
-    }
-  }, []);
+  const displayName =
+    userInfo?.email?.trim() || userInfo?.sign_in_id?.trim() || "ユーザー";
 
   const toggleMenu = () => setMenuOpen(!menuOpen);
   const openMfaDialog = async () => {
@@ -36,7 +25,7 @@ const HeaderUserbox = () => {
         onClick={toggleMenu}
         className="bg-transparent border-none text-white text-sm cursor-pointer"
       >
-        {email ? `${email} ▼` : "ユーザー ▼"}
+        {`${displayName} ▼`}
       </button>
       {menuOpen && (
         <div className="absolute top-12 right-5 bg-white text-black shadow-md rounded overflow-hidden min-w-[120px] z-50">
@@ -54,18 +43,6 @@ const HeaderUserbox = () => {
       />
     </header>
   );
-};
-
-// JWTのペイロード部分をデコードする関数
-const decodeJwtPayload = (token: string): { email?: string } | null => {
-  try {
-    const payloadBase64 = token.split(".")[1]; // JWTのペイロード部分
-    const payloadDecoded = atob(payloadBase64); // Base64デコード
-    return JSON.parse(payloadDecoded); // JSONに変換
-  } catch (error) {
-    console.error("JWTデコードエラー:", error);
-    return null;
-  }
 };
 
 export default HeaderUserbox;

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import type { UserInfo } from "../types";
+
+interface UserContextType {
+  userInfo: UserInfo | null;
+  setUserInfo: React.Dispatch<React.SetStateAction<UserInfo | null>>;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider = ({ children }: { children: ReactNode }) => {
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+
+  const value = useMemo(
+    () => ({ userInfo, setUserInfo }),
+    [userInfo]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};
+
+export const useUser = () => {
+  const context = useContext(UserContext);
+
+  if (!context) {
+    throw new Error("useUser must be used within UserProvider");
+  }
+
+  return context;
+};

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,10 +1,10 @@
 import { createContext, useContext, useMemo, useState } from "react";
-import type { ReactNode } from "react";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
 import type { UserInfo } from "../types";
 
 interface UserContextType {
   userInfo: UserInfo | null;
-  setUserInfo: React.Dispatch<React.SetStateAction<UserInfo | null>>;
+  setUserInfo: Dispatch<SetStateAction<UserInfo | null>>;
 }
 
 const UserContext = createContext<UserContextType | undefined>(undefined);

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -26,6 +26,10 @@ const formatAttributeValue = (value: any): string => {
   return String(value);
 };
 
+const getUserDisplayId = (email?: string, signInId?: string): string => {
+  return email?.trim() || signInId?.trim() || "　";
+};
+
 const UserPage = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [userinfo, setUserinfo] = useState<UserInfo | null>(null);
@@ -191,7 +195,10 @@ const UserPage = () => {
               <span className="font-medium text-gray-600">
                 メールアドレス：
               </span>
-              <span>{userinfo?.email || "未設定"}</span>
+              <span>
+                {getUserDisplayId(userinfo?.email, userinfo?.sign_in_id) ||
+                  "未設定"}
+              </span>
             </div>
           </div>
           <div className="flex flex-col">
@@ -232,7 +239,7 @@ const UserPage = () => {
                   名前
                 </th>
                 <th className="py-3 px-4 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
-                  メールアドレス
+                  メールアドレス / ログインID
                 </th>
                 {userAttributes &&
                   Object.keys(userAttributes).map((key) => (
@@ -252,7 +259,9 @@ const UserPage = () => {
                   <td className="py-3 px-4">{user.tenant_id}</td>
                   <td className="py-3 px-4">{user.id}</td>
                   <td className="py-3 px-4">{user.attributes?.name ?? "　"}</td>
-                  <td className="py-3 px-4">{user.email}</td>
+                  <td className="py-3 px-4">
+                    {getUserDisplayId(user.email, user.sign_in_id)}
+                  </td>
                   {userAttributes &&
                     Object.keys(userAttributes).map((key) => {
                       const attribute = userAttributes[key];

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -27,7 +27,9 @@ const formatAttributeValue = (value: any): string => {
 };
 
 const getUserDisplayId = (email?: string, signInId?: string): string => {
-  return email?.trim() || signInId?.trim() || "　";
+  const emailDisplayId = email?.trim();
+  const signInDisplayId = signInId?.trim();
+  return emailDisplayId || signInDisplayId || "";
 };
 
 const UserPage = () => {
@@ -193,7 +195,7 @@ const UserPage = () => {
             </div>
             <div className="mb-3">
               <span className="font-medium text-gray-600">
-                メールアドレス：
+                メールアドレス / ログインID：
               </span>
               <span>
                 {getUserDisplayId(userinfo?.email, userinfo?.sign_in_id) ||

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -113,6 +113,7 @@ export interface User {
   id: string;
   tenant_id: string;
   email: string;
+  sign_in_id?: string;
   attributes?: UserAttributeValues;
 }
 
@@ -122,6 +123,8 @@ export interface User {
 export interface UserInfo {
   id?: string;
   email: string;
+  sign_in_id?: string;
+  user_attribute?: Record<string, string | number | boolean | Date | undefined>;
   tenants: Tenant[];
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,7 +124,7 @@ export interface UserInfo {
   id?: string;
   email: string;
   sign_in_id?: string;
-  user_attribute?: Record<string, string | number | boolean | Date | undefined>;
+  user_attribute?: UserAttributeValues;
   tenants: Tenant[];
 }
 


### PR DESCRIPTION
## 概要

`/userinfo` の取得結果を `UserContext` で共有するように変更し、ヘッダー表示のロジックを JWT デコード依存から Context 参照へ移行しました。
あわせて、ユーザー一覧の表示を `email` / `sign_in_id` 両対応に統一し、実態に合わせた列名の修正を行っています。

## 変更内容

### 認証・コンテキスト関連

* **Auth.tsx**
  * `/userinfo` の取得結果を `UserContext` に保存する処理を追加。
  * `useEffect` の依存配列は `[]` を維持し、初回マウント時のみ実行される仕様としています。


* **型定義**
  * `UserInfo` および `User` 型に `sign_in_id` などの必要項目を追加・調整しました。



### コンポーネント関連

* **HeaderUserbox.tsx**
  * 表示ソースを従来の JWT デコードから Context の `userInfo` 参照に切り替え。
  * 表示優先順位を `email` → `sign_in_id` → `「ユーザー」`（フォールバック）の順に統一しました。


* **UserPage.tsx**
  * ユーザー一覧のヘッダー列名を「メールアドレス」から**「メールアドレス / ログインID」**に変更。
  * 表示データについても `email` または `sign_in_id` を表示できるようロジックを修正しました。



## 影響範囲

* ログイン後のヘッダー表示（ユーザー名/メールアドレス）
* 管理画面などのユーザー一覧表示
