### PR TITLE
トークンリフレッシュの不具合修正とaxiosインターセプターによるトークン管理の一元化

### DIFF
--- a/src/axiosInterceptor.ts
+++ b/src/axiosInterceptor.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { API_ENDPOINT, LOGIN_URL } from "./const";
 
+const ACCESS_TOKEN_REQUIRED_PATHS = ["/mfa_setup", "/mfa_verify", "/user_invitation"];
+
 let isRefreshing = false;
 let failedQueue: Array<{
   resolve: (value?: any) => void;
@@ -18,15 +20,27 @@ const processQueue = (error: any = null) => {
   failedQueue = [];
 };
 
+const decodeJwtPayload = (token: string): Record<string, unknown> => {
+  const base64Url = token.split(".")[1];
+  if (!base64Url) {
+    throw new Error("Invalid JWT payload");
+  }
+  const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+  const paddedBase64 = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    "="
+  );
+  const binary = window.atob(paddedBase64);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  const json = new TextDecoder().decode(bytes);
+  return JSON.parse(json) as Record<string, unknown>;
+};
+
 const isTokenExpired = (token: string): boolean => {
   try {
-    const base64Url = token.split(".")[1];
-    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
-    const decoded = JSON.parse(
-      decodeURIComponent(escape(window.atob(base64)))
-    );
+    const decoded = decodeJwtPayload(token);
     const expireDate = decoded["exp"] as number;
-    const timestamp = parseInt(Date.now().toString().slice(0, 10));
+    const timestamp = Math.floor(Date.now() / 1000);
     return expireDate <= timestamp;
   } catch {
     return true;
@@ -101,14 +115,14 @@ axios.interceptors.request.use(
     }
 
     // アクセストークンが必要なエンドポイントにのみセット
-    const ACCESS_TOKEN_REQUIRED_PATHS = [
-      "/mfa_setup",
-      "/mfa_verify",
-      "/user_invitation",
-    ];
-    const needsAccessToken = ACCESS_TOKEN_REQUIRED_PATHS.some((path) =>
-      config.url?.includes(path)
-    );
+    const needsAccessToken = ACCESS_TOKEN_REQUIRED_PATHS.some((path) => {
+      try {
+        const pathname = new URL(config.url!, window.location.origin).pathname;
+        return pathname === path;
+      } catch {
+        return false;
+      }
+    });
     if (needsAccessToken) {
       const accessToken = localStorage.getItem("SaaSusAccessToken");
       if (accessToken && config.headers) {

--- a/src/axiosInterceptor.ts
+++ b/src/axiosInterceptor.ts
@@ -1,0 +1,124 @@
+import axios from "axios";
+import { API_ENDPOINT, LOGIN_URL } from "./const";
+
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (value?: any) => void;
+  reject: (reason?: any) => void;
+}> = [];
+
+const processQueue = (error: any = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve();
+    }
+  });
+  failedQueue = [];
+};
+
+const isTokenExpired = (token: string): boolean => {
+  try {
+    const base64Url = token.split(".")[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const decoded = JSON.parse(
+      decodeURIComponent(escape(window.atob(base64)))
+    );
+    const expireDate = decoded["exp"] as number;
+    const timestamp = parseInt(Date.now().toString().slice(0, 10));
+    return expireDate <= timestamp;
+  } catch {
+    return true;
+  }
+};
+
+const refreshToken = async (): Promise<string> => {
+  const res = await axios.get(`${API_ENDPOINT}/refresh`, {
+    headers: {
+      "X-Requested-With": "XMLHttpRequest",
+    },
+    withCredentials: true,
+  });
+
+  const newIdToken = res.data.id_token;
+  localStorage.setItem("SaaSusIdToken", newIdToken);
+
+  const newAccessToken = res.data.access_token;
+  localStorage.setItem("SaaSusAccessToken", newAccessToken);
+
+  return newIdToken;
+};
+
+axios.interceptors.request.use(
+  async (config) => {
+    // refresh と credentials エンドポイントはインターセプターをスキップ
+    if (
+      config.url?.includes("/refresh") ||
+      config.url?.includes("/credentials")
+    ) {
+      return config;
+    }
+
+    const token = localStorage.getItem("SaaSusIdToken");
+
+    if (token && isTokenExpired(token)) {
+      if (!isRefreshing) {
+        isRefreshing = true;
+
+        try {
+          const newToken = await refreshToken();
+          isRefreshing = false;
+          processQueue();
+
+          if (config.headers) {
+            config.headers.Authorization = `Bearer ${newToken}`;
+          }
+        } catch (error) {
+          isRefreshing = false;
+          processQueue(error);
+          window.location.href = LOGIN_URL;
+          return Promise.reject(error);
+        }
+      } else {
+        // リフレッシュ中の場合はキューに追加して待機
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(() => {
+            const newToken = localStorage.getItem("SaaSusIdToken");
+            if (config.headers && newToken) {
+              config.headers.Authorization = `Bearer ${newToken}`;
+            }
+            return config;
+          })
+          .catch((err) => {
+            return Promise.reject(err);
+          });
+      }
+    } else if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    // アクセストークンが必要なエンドポイントにのみセット
+    const ACCESS_TOKEN_REQUIRED_PATHS = [
+      "/mfa_setup",
+      "/mfa_verify",
+      "/user_invitation",
+    ];
+    const needsAccessToken = ACCESS_TOKEN_REQUIRED_PATHS.some((path) =>
+      config.url?.includes(path)
+    );
+    if (needsAccessToken) {
+      const accessToken = localStorage.getItem("SaaSusAccessToken");
+      if (accessToken && config.headers) {
+        config.headers["X-Access-Token"] = accessToken;
+      }
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -12,11 +12,9 @@ const Auth = () => {
   // ログインユーザの情報を取得
   const getUserInfo = async () => {
     try {
-      const jwtToken = window.localStorage.getItem("SaaSusIdToken");
       const res = await axios.get<UserInfo>(`${API_ENDPOINT}/userinfo`, {
         headers: {
           "X-Requested-With": "XMLHttpRequest",
-          Authorization: `Bearer ${jwtToken}`,
           "X-SaaSus-Referer": location.pathname,
         },
         withCredentials: true,

--- a/src/components/dialogs/UserMfaSettingDialog.tsx
+++ b/src/components/dialogs/UserMfaSettingDialog.tsx
@@ -3,7 +3,6 @@ import { useLocation } from "react-router-dom";
 import { API_ENDPOINT } from "../../const";
 import axios from "axios";
 import { QRCodeCanvas } from "qrcode.react";
-import { idTokenCheck } from "../../utils";
 import { ApiError, MfaSetupResponse, MfaStatusResponse } from "../../types";
 
 type Props = {
@@ -18,18 +17,11 @@ const UserMfaSettingDialog = ({ open, handleClose }: Props) => {
   const [showQrCode, setShowQrCode] = useState(false); // QRコード表示フラグ
   const [isFeatureAvailable, setIsFeatureAvailable] = useState(true); // 機能が利用可能か
   const [error, setError] = useState("");
-  const [jwtToken, setJwtToken] = useState(
-    localStorage.getItem("SaaSusIdToken") as string
-  );
-  const [accessToken, setAccessToken] = useState(
-    localStorage.getItem("SaaSusAccessToken") as string | null
-  );
   const location = useLocation();
   const pagePath = location.pathname;
   // ページ内で共通して使用するヘッダーを定義
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath, // すべてのAPIでこの共通のパスを使用
   };
   const getActionHeaders = (actionName: string) => {
@@ -38,17 +30,10 @@ const UserMfaSettingDialog = ({ open, handleClose }: Props) => {
       "X-SaaSus-Referer": `${pagePath}?action=${actionName}`,
     };
   };
-  // ダイアログが開いた時にトークンをチェック＆最新のトークンをセット
   useEffect(() => {
-    const updateTokensAndCheckStatus = async () => {
-      await idTokenCheck(localStorage.getItem("SaaSusIdToken") as string);
-      setJwtToken(localStorage.getItem("SaaSusIdToken") as string);
-      setAccessToken(localStorage.getItem("SaaSusAccessToken"));
-      await checkMfaStatus();
-    };
     if (open) {
       setShowQrCode(false);
-      updateTokensAndCheckStatus();
+      checkMfaStatus();
     }
   }, [open]);
 
@@ -83,18 +68,11 @@ const UserMfaSettingDialog = ({ open, handleClose }: Props) => {
 
   // QRコードを取得する
   const fetchMfaSetup = async () => {
-    if (!accessToken) {
-      setError("アクセストークンがありません");
-      return;
-    }
     try {
       const response = await axios.get<MfaSetupResponse>(
         `${API_ENDPOINT}/mfa_setup`,
         {
-          headers: {
-            ...commonHeaders,
-            "X-Access-Token": accessToken,
-          },
+          headers: commonHeaders,
           withCredentials: true,
         }
       );
@@ -113,19 +91,12 @@ const UserMfaSettingDialog = ({ open, handleClose }: Props) => {
       setError("認証コードを入力してください");
       return;
     }
-    if (!accessToken) {
-      setError("アクセストークンがありません");
-      return;
-    }
     try {
       const response = await axios.post(
         `${API_ENDPOINT}/mfa_verify`,
         { verification_code: verificationCode },
         {
-          headers: {
-            ...getActionHeaders("mfa_verify"),
-            "X-Access-Token": accessToken,
-          },
+          headers: getActionHeaders("mfa_verify"),
           withCredentials: true,
         }
       );
@@ -197,10 +168,7 @@ const UserMfaSettingDialog = ({ open, handleClose }: Props) => {
             {!showQrCode ? (
               <>
                 <button
-                  onClick={() => {
-                    fetchMfaSetup();
-                    setShowQrCode(true);
-                  }}
+                  onClick={fetchMfaSetup}
                   className="w-full py-3 bg-blue-600 text-white rounded-md mb-2 hover:bg-blue-700"
                 >
                   デバイスを再登録
@@ -246,10 +214,7 @@ const UserMfaSettingDialog = ({ open, handleClose }: Props) => {
                   デバイスが設定されていません。有効にするにはデバイスを追加してください。
                 </p>
                 <button
-                  onClick={() => {
-                    fetchMfaSetup();
-                    setShowQrCode(true);
-                  }}
+                  onClick={fetchMfaSetup}
                   className="w-full py-3 bg-blue-600 text-white rounded-md mb-2 hover:bg-blue-700"
                 >
                   デバイスを追加する

--- a/src/components/header/HeaderUserbox.tsx
+++ b/src/components/header/HeaderUserbox.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import UserMfaSettingDialog from "../dialogs/UserMfaSettingDialog";
-import { idTokenCheck } from "../../utils";
 import { useUser } from "../../contexts/UserContext";
 
 const HeaderUserbox = () => {
@@ -12,9 +11,8 @@ const HeaderUserbox = () => {
     userInfo?.email?.trim() || userInfo?.sign_in_id?.trim() || "ユーザー";
 
   const toggleMenu = () => setMenuOpen(!menuOpen);
-  const openMfaDialog = async () => {
+  const openMfaDialog = () => {
     setMenuOpen(false);
-    await idTokenCheck(localStorage.getItem("SaaSusIdToken") as string);
     setMfaDialogOpen(true);
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import "./axiosInterceptor";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement

--- a/src/pages/BillingDashboard.tsx
+++ b/src/pages/BillingDashboard.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
 import {
-  idTokenCheck,
   randomUnixBetween,
   navigateToUserPageByRole,
 } from "../utils";
@@ -44,13 +43,11 @@ const BillingDashboard = () => {
     return [404, 501, 502, 503, 504].includes(err.response.status);
   };
   const navigate = useNavigate();
-  let jwtToken = window.localStorage.getItem("SaaSusIdToken") as string;
   const location = useLocation();
   const pagePath = location.pathname;
   // ページ内で共通して使用するヘッダーを定義
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath, // すべてのAPIでこの共通のパスを使用
   };
   const getMeteringActionHeaders = (
@@ -268,16 +265,12 @@ const BillingDashboard = () => {
   };
 
   useEffect(() => {
-    if (jwtToken && tenantId) {
+    if (tenantId) {
       fetchPeriodOptions();
     }
-  }, [jwtToken, tenantId]);
+  }, [tenantId]);
   useEffect(() => {
-    const initializePage = async () => {
-      await idTokenCheck(jwtToken);
-      await getUserinfo();
-    };
-    initializePage();
+    getUserinfo();
   }, []);
 
   useEffect(() => {

--- a/src/pages/Callback.tsx
+++ b/src/pages/Callback.tsx
@@ -36,11 +36,9 @@ const Callback = () => {
   // ロールによって遷移先を振り分け
   const navigateByRole = async () => {
     // ロールの取得
-    const jwtToken = window.localStorage.getItem("SaaSusIdToken");
     const res = await axios.get(`${API_ENDPOINT}/userinfo`, {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
-        Authorization: `Bearer ${jwtToken}`,
         "X-SaaSus-Referer": pagePath,
       },
       withCredentials: true,
@@ -62,11 +60,9 @@ const Callback = () => {
 
   // 遷移先判定
   const handleUserNavigation = async () => {
-    const jwtToken = window.localStorage.getItem("SaaSusIdToken");
     const res = await axios.get(`${API_ENDPOINT}/userinfo`, {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
-        Authorization: `Bearer ${jwtToken}`,
         "X-SaaSus-Referer": pagePath,
       },
       withCredentials: true,

--- a/src/pages/DeleteUserLog.tsx
+++ b/src/pages/DeleteUserLog.tsx
@@ -2,20 +2,17 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { API_ENDPOINT } from "../const";
-import { idTokenCheck } from "../utils";
 import { DeletedUser, UserInfo } from "../types";
 
 const DeleteUserLog = () => {
   const [deleteUsers, setDeleteUsers] = useState<DeletedUser[]>([]);
   const [userinfo, setUserinfo] = useState<UserInfo | null>(null);
   const [tenantId, setTenantId] = useState<string | null>(null);
-  let jwtToken = window.localStorage.getItem("SaaSusIdToken") as string;
   const location = useLocation();
   const pagePath = location.pathname;
   // ページ内で共通して使用するヘッダーを定義
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath, // すべてのAPIでこの共通のパスを使用
   };
   // ユーザー削除ログを取得
@@ -62,7 +59,6 @@ const DeleteUserLog = () => {
       const urlParams = new URLSearchParams(window.location.search);
       const tenantIdFromQuery = urlParams.get("tenant_id");
       setTenantId(tenantIdFromQuery);
-      await idTokenCheck(jwtToken);
       await GetUserinfo();
     };
     startUserPage();

--- a/src/pages/DeleteUserLog.tsx
+++ b/src/pages/DeleteUserLog.tsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { API_ENDPOINT } from "../const";
 import { DeletedUser, UserInfo } from "../types";
 
@@ -116,12 +116,12 @@ const DeleteUserLog = () => {
       </div>
 
       <div className="mt-4">
-        <a
-          href={`/admin/toppage?tenant_id=${tenantId}`}
+        <Link
+          to={`/admin/toppage?tenant_id=${tenantId}`}
           className="text-blue-600 hover:text-blue-800 hover:underline"
         >
           ユーザー一覧に戻る
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/PlanSettings.tsx
+++ b/src/pages/PlanSettings.tsx
@@ -1,8 +1,8 @@
 import axios from "axios";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { API_ENDPOINT } from "../const";
-import { idTokenCheck, navigateToUserPageByRole } from "../utils";
+import { navigateToUserPageByRole } from "../utils";
 import { Tenant } from "../types";
 import { PlanInfo, TaxRate, PricingPlan } from "../types/billing";
 import ErrorDialog from "../components/dialogs/ErrorDialog";
@@ -93,11 +93,8 @@ const PlanSettings = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const pagePath = location.pathname;
-  const jwtToken = window.localStorage.getItem("SaaSusIdToken") as string;
-
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath,
   };
 
@@ -306,7 +303,6 @@ const PlanSettings = () => {
       }
 
       setTenantId(tenantIdFromQuery);
-      await idTokenCheck(jwtToken);
       await getTenantInfo(tenantIdFromQuery);
       await getPricingPlans();
       await getTaxRates();

--- a/src/pages/SelfSignUp.tsx
+++ b/src/pages/SelfSignUp.tsx
@@ -2,7 +2,6 @@ import axios from "axios";
 import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
-import { idTokenCheck } from "../utils";
 import {
   UserAttribute,
   TenantAttribute,
@@ -84,13 +83,11 @@ const SelfSignup = () => {
   const [tenantAttributeValues, setTenantAttributeValues] =
     useState<TenantAttributeValues>({});
   const navigate = useNavigate();
-  let jwtToken = window.localStorage.getItem("SaaSusIdToken") as string;
   const location = useLocation();
   const pagePath = location.pathname;
   // ページ内で共通して使用するヘッダーを定義
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath, // すべてのAPIでこの共通のパスを使用
   };
 
@@ -149,11 +146,7 @@ const SelfSignup = () => {
   };
 
   useEffect(() => {
-    const startUserRegisterPage = async () => {
-      await idTokenCheck(jwtToken);
-      await Promise.all([GetUserAttributes(), GetTenantAttributes()]);
-    };
-    startUserRegisterPage();
+    Promise.all([GetUserAttributes(), GetTenantAttributes()]);
   }, []);
 
   const handleSubmit = async (event: React.FormEvent) => {

--- a/src/pages/TenantList.tsx
+++ b/src/pages/TenantList.tsx
@@ -2,7 +2,7 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { API_ENDPOINT } from "../const";
-import { idTokenCheck, navigateToUserPageByRole } from "../utils";
+import { navigateToUserPageByRole } from "../utils";
 import { Tenant, UserInfo, TenantAttributesResponse } from "../types";
 
 // テナント属性の値を適切にフォーマットする関数
@@ -31,13 +31,11 @@ const TenantList = () => {
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [tenantInfo, setTenantInfo] = useState<any[]>([]);
   const navigate = useNavigate();
-  let jwtToken = window.localStorage.getItem("SaaSusIdToken") as string;
   const location = useLocation();
   const pagePath = location.pathname;
   // ページ内で共通して使用するヘッダーを定義
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath, // すべてのAPIでこの共通のパスを使用
   };
 
@@ -70,11 +68,7 @@ const TenantList = () => {
   };
 
   useEffect(() => {
-    const startTenantListPage = async () => {
-      await idTokenCheck(jwtToken);
-      GetUserinfo();
-    };
-    startTenantListPage();
+    GetUserinfo();
   }, []);
 
   return (

--- a/src/pages/UserInvitation.tsx
+++ b/src/pages/UserInvitation.tsx
@@ -2,7 +2,6 @@ import axios from "axios";
 import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
-import { idTokenCheck } from "../utils";
 import { ApiError, Invitation } from "../types";
 
 const UserInvitation = () => {
@@ -10,16 +9,11 @@ const UserInvitation = () => {
   const [tenantId, setTenantId] = useState<string | null>(null);
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [error, setError] = useState("");
-  const accessToken = window.localStorage.getItem(
-    "SaaSusAccessToken"
-  ) as string;
-  let jwtToken = window.localStorage.getItem("SaaSusIdToken") as string;
   const location = useLocation();
   const pagePath = location.pathname;
   // ページ内で共通して使用するヘッダーを定義
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath, // すべてのAPIでこの共通のパスを使用
   };
   // ユーザ一覧取得
@@ -29,7 +23,6 @@ const UserInvitation = () => {
       const res = await axios.get<Invitation[]>(`${API_ENDPOINT}/invitations`, {
         headers: {
           "X-Requested-With": "XMLHttpRequest",
-          Authorization: `Bearer ${jwtToken}`,
         },
         withCredentials: true,
         params: {
@@ -58,7 +51,6 @@ const UserInvitation = () => {
       const tenantIdFromQuery = urlParams.get("tenant_id");
       setTenantId(tenantIdFromQuery);
       getInvitations(tenantIdFromQuery);
-      await idTokenCheck(jwtToken);
     };
     startUserRegisterPage();
   }, []);
@@ -68,7 +60,6 @@ const UserInvitation = () => {
     const postHeaders = {
       ...commonHeaders,
       "X-SaaSus-Referer": `${pagePath}?action=user_invitation`,
-      "X-Access-Token": accessToken, // accessTokenを追加
     };
     try {
       const response = await axios.post(

--- a/src/pages/UserInvitation.tsx
+++ b/src/pages/UserInvitation.tsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
 import { ApiError, Invitation } from "../types";
 
@@ -73,9 +73,9 @@ const UserInvitation = () => {
           withCredentials: true,
         }
       );
-      // リダイレクトはaxiosの成功後に行う
       if (response.status === 200) {
-        window.location.href = `/user_invitation?tenant_id=${tenantId}`;
+        setEmail("");
+        getInvitations(tenantId);
       }
     } catch (err: unknown) {
       const error = err as ApiError;
@@ -211,12 +211,12 @@ const UserInvitation = () => {
 
       {/* ユーザー一覧に戻るリンク */}
       <div className="mt-4">
-        <a
-          href={`/admin/toppage?tenant_id=${tenantId}`}
+        <Link
+          to={`/admin/toppage?tenant_id=${tenantId}`}
           className="text-blue-600 hover:text-blue-800 hover:underline"
         >
           ユーザー一覧に戻る
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -2,7 +2,6 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
-import { idTokenCheck } from "../utils";
 import {
   User,
   UserInfo,
@@ -43,13 +42,11 @@ const UserPage = () => {
   const [tenantUserInfo, setTenantUserInfo] = useState<Tenant | null>(null);
   const [planInfo, setPlanInfo] = useState<PlanInfo | null>(null);
   const [roleName, setRoleName] = useState<string>("");
-  let jwtToken = window.localStorage.getItem("SaaSusIdToken") as string;
   const location = useLocation();
   const pagePath = location.pathname;
   // ページ内で共通して使用するヘッダーを定義
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath, // すべてのAPIでこの共通のパスを使用
   };
   const getActionHeaders = (actionName: string) => {
@@ -149,7 +146,6 @@ const UserPage = () => {
       const urlParams = new URLSearchParams(window.location.search);
       const tenantIdFromQuery = urlParams.get("tenant_id");
       setTenantId(tenantIdFromQuery);
-      await idTokenCheck(jwtToken);
       getUsers(tenantIdFromQuery);
       GetUserinfo(tenantIdFromQuery);
       GetUserAttributes();

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, Link } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
 import {
   User,
@@ -300,36 +300,36 @@ const UserPage = () => {
           <h2 className="text-lg font-semibold mb-4 text-gray-800">管理機能</h2>
           <div className="space-y-3">
             <div>
-              <a
-                href={`/billing?tenant_id=${tenantId}`}
+              <Link
+                to={`/billing?tenant_id=${tenantId}`}
                 className="text-blue-600 hover:text-blue-800 hover:underline"
               >
                 課金情報
-              </a>
+              </Link>
             </div>
             <div>
-              <a
-                href={`/user_register?tenant_id=${tenantId}`}
+              <Link
+                to={`/user_register?tenant_id=${tenantId}`}
                 className="text-blue-600 hover:text-blue-800 hover:underline"
               >
                 ユーザー新規登録
-              </a>
+              </Link>
             </div>
             <div>
-              <a
-                href={`/delete_user_log?tenant_id=${tenantId}`}
+              <Link
+                to={`/delete_user_log?tenant_id=${tenantId}`}
                 className="text-blue-600 hover:text-blue-800 hover:underline"
               >
                 ユーザー削除ログ
-              </a>
+              </Link>
             </div>
             <div className="flex items-start">
-              <a
-                href={`/user_invitation?tenant_id=${tenantId}`}
+              <Link
+                to={`/user_invitation?tenant_id=${tenantId}`}
                 className="text-blue-600 hover:text-blue-800 hover:underline"
               >
                 ユーザー招待
-              </a>
+              </Link>
               <span className="ml-2 text-red-600 text-sm">
                 ※ユーザー招待機能を利用するには、SaaSus Platform
                 でドメイン名を設定し、DNS
@@ -337,12 +337,12 @@ const UserPage = () => {
               </span>
             </div>
             <div>
-              <a
-                href={`/plan-settings?tenant_id=${tenantId}`}
+              <Link
+                to={`/plan-settings?tenant_id=${tenantId}`}
                 className="text-blue-600 hover:text-blue-800 hover:underline"
               >
                 プラン設定
-              </a>
+              </Link>
             </div>
 
           </div>
@@ -354,12 +354,12 @@ const UserPage = () => {
         {/* テナント一覧に戻るリンク（複数テナントに所属している場合のみ表示） */}
         {userinfo && userinfo.tenants && userinfo.tenants.length > 1 && (
           <div>
-            <a
-              href="/tenants"
+            <Link
+              to="/tenants"
               className="text-blue-600 hover:text-blue-800 hover:underline"
             >
               テナント一覧に戻る
-            </a>
+            </Link>
           </div>
         )}
         

--- a/src/pages/UserRegister.tsx
+++ b/src/pages/UserRegister.tsx
@@ -2,7 +2,6 @@ import axios from "axios";
 import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
-import { idTokenCheck } from "../utils";
 import {
   UserAttribute,
   UserAttributeValues,
@@ -76,13 +75,11 @@ const UserRegister = () => {
   const [userAttributeValues, setUserAttributeValues] =
     useState<UserAttributeValues>({});
   const navigate = useNavigate();
-  let jwtToken = window.localStorage.getItem("SaaSusIdToken") as string;
   const location = useLocation();
   const pagePath = location.pathname;
   // ページ内で共通して使用するヘッダーを定義
   const commonHeaders = {
     "X-Requested-With": "XMLHttpRequest",
-    Authorization: `Bearer ${jwtToken}`,
     "X-SaaSus-Referer": pagePath, // すべてのAPIでこの共通のパスを使用
   };
 
@@ -105,7 +102,6 @@ const UserRegister = () => {
       const urlParams = new URLSearchParams(window.location.search);
       const tenantIdFromQuery = urlParams.get("tenant_id");
       setTenantId(tenantIdFromQuery);
-      await idTokenCheck(jwtToken);
       GetUserAttributes();
     };
 

--- a/src/pages/UserRegister.tsx
+++ b/src/pages/UserRegister.tsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, Link } from "react-router-dom";
 import { API_ENDPOINT, LOGIN_URL } from "../const";
 import {
   UserAttribute,
@@ -233,12 +233,12 @@ const UserRegister = () => {
       </div>
 
       <div className="mt-4 text-center">
-        <a
-          href={`/admin/toppage?tenant_id=${tenantId}`}
+        <Link
+          to={`/admin/toppage?tenant_id=${tenantId}`}
           className="text-blue-600 hover:text-blue-800 hover:underline"
         >
           ユーザー一覧に戻る
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,47 +1,6 @@
 import axios from "axios";
-import { API_ENDPOINT, LOGIN_URL } from "./const";
+import { API_ENDPOINT } from "./const";
 import { UserInfo, Tenant } from "./types";
-
-type Jwt = {
-  [name: string]: string | number | boolean;
-};
-
-const sleep = (second: number) =>
-  new Promise((resolve) => setTimeout(resolve, second * 1000));
-
-export const idTokenCheck = async (jwtToken: string) => {
-  const base64Url = jwtToken.split(".")[1];
-  const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
-  const decoded = JSON.parse(
-    decodeURIComponent(escape(window.atob(base64)))
-  ) as Jwt;
-
-  const expireDate = decoded["exp"] as number;
-  const timestamp = parseInt(Date.now().toString().slice(0, 10));
-  if (expireDate <= timestamp) {
-    try {
-      console.log("token expired");
-      const res = await axios.get(`${API_ENDPOINT}/refresh`, {
-        headers: {
-          "X-Requested-With": "XMLHttpRequest",
-        },
-        withCredentials: true,
-      });
-
-      jwtToken = res.data.id_token;
-      localStorage.setItem("SaaSusIdToken", jwtToken);
-
-      const accessToken = res.data.access_token;
-      localStorage.setItem("SaaSusAccessToken", accessToken);
-
-      await sleep(1);
-      return;
-    } catch (err) {
-      console.log(err);
-      window.location.href = LOGIN_URL;
-    }
-  }
-};
 
 /**
  * 指定された UNIX タイムスタンプの範囲内でランダムな整数（秒）を返す
@@ -62,17 +21,15 @@ export const randomUnixBetween = (start: number, end: number): number => {
  * @param pagePath 現在のページパス
  */
 export const navigateToUserPageByRole = async (
-  tenantId: string, 
+  tenantId: string,
   navigate: (path: string) => void,
   pagePath: string
 ) => {
   try {
     // ロールの取得
-    const jwtToken = window.localStorage.getItem("SaaSusIdToken");
     const res = await axios.get<UserInfo>(`${API_ENDPOINT}/userinfo`, {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
-        Authorization: `Bearer ${jwtToken}`,
         "X-SaaSus-Referer": pagePath,
       },
       withCredentials: true,
@@ -102,4 +59,3 @@ export const navigateToUserPageByRole = async (
     navigate(`/user/toppage?tenant_id=${tenantId}`);
   }
 };
-


### PR DESCRIPTION
トークンの有効期限切れ時にリフレッシュ処理が各コンポーネントに分散しており、リフレッシュ後も古いトークンが使われる不具合が発生していた。また X-Access-Token を各コンポーネントで手動管理していたため、取得タイミングによって古い値が送信されるリスクがあった。

### 変更内容

### メイン：axiosインターセプターによるトークン管理の一元化
- リクエスト前にトークンの有効期限を自動チェックし、期限切れの場合はリフレッシュしてから送信
- X-Access-Token はMFA・ユーザー招待の必要なエンドポイントにのみ自動付与（不要な露出を防止）
- 各コンポーネントでの手動トークン管理を削除
### サブ：`<a href>` を `<Link>` に置き換え
- アプリ内遷移のフルリロードを防止し、Auth の不要な再マウントを解消