### PR TITLE
trace_id引継ぎ機能の実装

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,22 @@
+import axios from "axios";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+
+const getTraceId = (): string => {
+  const key = "SaaSusTraceId";
+  let traceId = sessionStorage.getItem(key);
+  if (!traceId) {
+    traceId = crypto.randomUUID();
+    sessionStorage.setItem(key, traceId);
+  }
+  return traceId;
+};
+
+axios.interceptors.request.use((config) => {
+  config.headers["X-Saasus-Trace-Id"] = getTraceId();
+  return config;
+});
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement


### PR DESCRIPTION
### 背景・目的
フロントエンドからバックエンドへのAPIリクエストを追跡可能にするため、セッション固有のTrace IDを全リクエストに付与する仕組みを導入した。

### 変更内容
`index.tsx`に `getTraceId()`関数を追加
`sessionStorage`にTrace IDを保持し、セッション単位で同一IDを使い回す
IDが存在しない場合は `crypto.randomUUID()`で新規生成
axiosのグローバルリクエストインターセプターに X-Saasus-Trace-Id ヘッダーの付与処理を追加
### 動作

- ユーザーがタブを開いた時点でTrace IDが生成される
- そのタブのセッション中は全axiosリクエストに同一のTrace IDが付与される
- タブを閉じると次回は新しいIDが生成される

### 影響範囲
全axiosリクエストにヘッダーが追加されるが、既存の動作への影響はなし